### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Easy drop-in component for iOS developers to deal easy with PIN (4 digit passcode) logic. 
 This is the first version but we truly tried to make it reusable and customizable enough to save development time.
 
-###How to Use:
+### How to Use:
 1) Subclass APPinViewController:
 
     @interface SamplePinViewController : APPinViewController
@@ -12,7 +12,7 @@ This is the first version but we truly tried to make it reusable and customizabl
 
 ..and this is it.
 
-####To Set PIN:
+#### To Set PIN:
     SamplePinViewController *pinVC = [SamplePinViewController new];
     [self.navigationController pushViewController:pinVC animated:YES];
 
@@ -24,7 +24,7 @@ Delegate:
         [self.navigationController popViewControllerAnimated:YES];
     }
     
-####To Verify PIN:
+#### To Verify PIN:
 
     SamplePinViewController *pinVC = [SamplePinViewController new];
     pinVC.pinCodeToCheck = <#Your Pin To Verify#>;
@@ -37,7 +37,7 @@ Delegate:
         [self.navigationController popViewControllerAnimated:YES];
     }
     
-####To Change PIN:
+#### To Change PIN:
 
     SamplePinViewController *pinVC = [SamplePinViewController new];
     pinVC.pinCodeToCheck = <#Your Pin To Change#>;
@@ -56,13 +56,13 @@ Delegate:
 
     - (void)pinCodeViewController:(APPinViewController *)controller didFailVerificationWithCount:(NSUInteger)failsCount;
 
-####...and One More Thing:
+#### ...and One More Thing:
 You can feel free to customize pin view by changing its frame and position and set image for pins:
 
     self.pinCodeView.selectedPinImage = <#Your UIImage#>
     self.pinCodeView.normalPinImage = <#Your UIImage#>
     
-####Example screenshots:
+#### Example screenshots:
 
 <table border-width=0><tr>
 <td><img width=320 src="https://dl.dropboxusercontent.com/u/11819370/APPin/screen1.png"></td>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
